### PR TITLE
Unit Test Enum #37

### DIFF
--- a/src/test/java/com/ecommerce/model/CategoryTest.java
+++ b/src/test/java/com/ecommerce/model/CategoryTest.java
@@ -1,0 +1,33 @@
+package com.ecommerce.model;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CategoryTest {
+
+    @Test
+    void testCategoryDescription() {
+
+        Assertions.assertEquals("Eletrônicos", Category.ELETRONICS.getDescription());
+        Assertions.assertEquals("Roupas", Category.CLOTHING.getDescription());
+        Assertions.assertEquals("Casa & Jardim", Category.HOME_GARDEN.getDescription());
+        Assertions.assertEquals("Esportes", Category.SPORTS.getDescription());
+        Assertions.assertEquals("Brinquedos", Category.TOYS.getDescription());
+        Assertions.assertEquals("Beleza", Category.BEAUTY.getDescription());
+        Assertions.assertEquals("Automotivo", Category.AUTOMOTIVE.getDescription());
+
+    }
+
+    @Test
+    void testCategoryIcons() {
+
+        Assertions.assertEquals("fa-mobile-alt", Category.ELETRONICS.getIcon());
+        Assertions.assertEquals("fa-tshirt", Category.CLOTHING.getIcon());
+        Assertions.assertEquals("fa-chair", Category.HOME_GARDEN.getIcon());
+        Assertions.assertEquals("fa-running", Category.SPORTS.getIcon());
+        Assertions.assertEquals("fa-puzzle-piece", Category.TOYS.getIcon());
+        Assertions.assertEquals("fa-magic", Category.BEAUTY.getIcon());
+        Assertions.assertEquals("fa-car", Category.AUTOMOTIVE.getIcon());
+
+    }
+}

--- a/src/test/java/com/ecommerce/model/OrderStatusTest.java
+++ b/src/test/java/com/ecommerce/model/OrderStatusTest.java
@@ -1,0 +1,29 @@
+package com.ecommerce.model;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class OrderStatusTest {
+
+    @Test
+    void testOrderStatusDescription() {
+
+        Assertions.assertEquals("Pendente", Order.OrderStatus.PENDING.getDescription());
+        Assertions.assertEquals("Confirmado", Order.OrderStatus.CONFIRMED.getDescription());
+        Assertions.assertEquals("Pago", Order.OrderStatus.PAID.getDescription());
+        Assertions.assertEquals("Enviado", Order.OrderStatus.SHIPPED.getDescription());
+        Assertions.assertEquals("Entregue", Order.OrderStatus.DELIVERED.getDescription());
+        Assertions.assertEquals("Cancelado", Order.OrderStatus.CANCELLED.getDescription());
+
+    }
+
+    @Test
+    void testOrderPaymentMethodDescription() {
+
+        Assertions.assertEquals("Pix", Order.PaymentMethod.PIX.getDescription());
+        Assertions.assertEquals("Cartão de Crédito", Order.PaymentMethod.CREDIT_CARD.getDescription());
+        Assertions.assertEquals("Cartão de Débito", Order.PaymentMethod.DEBIT_CARD.getDescription());
+        Assertions.assertEquals("Boleto Bancário", Order.PaymentMethod.BANK_TICKET.getDescription());
+
+    }
+}


### PR DESCRIPTION
## 📌 Added

* Unit tests for `Order` enum covering `OrderStatus` and `PaymentMethod` descriptions
* Unit tests for `Category` enum validating descriptions and icon mappings
* Assertions to ensure all enum values return the expected human-readable values

---

## 🛠 Changed

* Improved test coverage for model layer by including enum validations

---

## 🐛 Fixed

* Ensured consistency between enum values and their corresponding descriptions and icons

---

## 🎯 Related Issues

Closes #37
